### PR TITLE
Rewrite for loop in EvoUI.inputCheckboxes()

### DIFF
--- a/js/structured-filter.js
+++ b/js/structured-filter.js
@@ -636,7 +636,7 @@ var EvoUI={
 	},
 	inputCheckboxes:function(fLOV){
 		var h='';
-		for(var i in fLOV){
+		for(var i=0;i<fLOV.length;i++){
 			var lv=fLOV[i];
 			h+='<input type="checkbox" id="'+lv.id+'" value="'+lv.id+'"/>'+
 				'<label for="'+lv.id+'">'+lv.label+'</label> ';


### PR DESCRIPTION
Super cool widget ! I was looking for exactly this. Thanks.

Found a small thing though, I think it's a bug in the code, but it might also be something else that interferes.

This line produced 30-40 extra checkboxes on my Chrome, because the array has extra properties or methods (each, push etc.).

This commit solved it for me. Is that a local thing here that messes things up ?

/Lars